### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.Configuration.Metadata.nuspec
+++ b/MakoIoT.Device.Services.Configuration.Metadata.nuspec
@@ -17,7 +17,7 @@
     <description>Configuration metadata tools for MAKO-IoT device config API and app.</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot configuration api metadata</tags>
     <dependencies>
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.42.48151" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.43.29288" />
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
       <dependency id="nanoFramework.System.Collections" version="1.5.31" />
       <dependency id="nanoFramework.System.Text" version="1.2.54" />

--- a/src/MakoIoT.Device.Services.Configuration.Metadata/MakoIoT.Device.Services.Configuration.Metadata.nfproj
+++ b/src/MakoIoT.Device.Services.Configuration.Metadata/MakoIoT.Device.Services.Configuration.Metadata.nfproj
@@ -28,7 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.42.48151\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.43.29288\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/src/MakoIoT.Device.Services.Configuration.Metadata/packages.config
+++ b/src/MakoIoT.Device.Services.Configuration.Metadata/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.42.48151" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.43.29288" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Interface from 1.0.42.48151 to 1.0.43.29288</br>
[version update]

### :warning: This is an automated update. :warning:
